### PR TITLE
Thread Safety

### DIFF
--- a/pymunk/shapes.py
+++ b/pymunk/shapes.py
@@ -14,6 +14,9 @@ from .contact_point_set import ContactPointSet
 from .vec2d import Vec2d
 from ._pickle import PickleMixin
 
+from threading import Lock
+shape_id_lock = Lock()
+
 class Shape(PickleMixin, object):
     """Base class for all the shapes.
 
@@ -41,10 +44,11 @@ class Shape(PickleMixin, object):
     def _get_shapeid(self):
         return cp.cpShapeGetUserData(self._shape)
     def _set_shapeid(self):
-        cp.cpShapeSetUserData(
-            self._shape, 
-            ffi.cast("cpDataPointer", Shape._shapeid_counter))
-        Shape._shapeid_counter += 1
+        with shape_id_lock:
+            cp.cpShapeSetUserData(
+                self._shape,
+                ffi.cast("cpDataPointer", Shape._shapeid_counter))
+            Shape._shapeid_counter += 1
 
     def _get_mass(self):
         return cp.cpShapeGetMass(self._shape)

--- a/pymunk/shapes.py
+++ b/pymunk/shapes.py
@@ -1,6 +1,7 @@
 __docformat__ = "reStructuredText"
 
 import copy
+import threading
 
 from . import _chipmunk_cffi
 cp = _chipmunk_cffi.lib
@@ -14,8 +15,7 @@ from .contact_point_set import ContactPointSet
 from .vec2d import Vec2d
 from ._pickle import PickleMixin
 
-from threading import Lock
-shape_id_lock = Lock()
+_shape_id_lock = threading.Lock()
 
 class Shape(PickleMixin, object):
     """Base class for all the shapes.
@@ -44,7 +44,7 @@ class Shape(PickleMixin, object):
     def _get_shapeid(self):
         return cp.cpShapeGetUserData(self._shape)
     def _set_shapeid(self):
-        with shape_id_lock:
+        with _shape_id_lock:
             cp.cpShapeSetUserData(
                 self._shape,
                 ffi.cast("cpDataPointer", Shape._shapeid_counter))

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -4,7 +4,10 @@ import weakref
 import platform
 import copy
 import threading
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 
 from . import _chipmunk_cffi
 cp = _chipmunk_cffi.lib

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -4,10 +4,7 @@ import weakref
 import platform
 import copy
 import threading
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import collections
 
 from . import _chipmunk_cffi
 cp = _chipmunk_cffi.lib
@@ -22,6 +19,33 @@ from .contact_point_set import ContactPointSet
 from ._pickle import PickleMixin
 from pymunk.constraint import Constraint
 
+class AsyncHandler(threading.Thread):
+    def __init__(self, space):
+        self.space = space
+        self.do_event = threading.Event()
+        self.free_event = threading.Event()
+        threading.Thread.__init__(self, name="AsyncHandler({})".format(self.space), daemon=False)
+
+    def run(self):
+        space = self.space
+        while 1:
+            self.do_event.wait()
+            self.free_event.clear()
+            with space._in_step:
+                for i in range(len(space._add_later)):
+                    objs = space._add_later.popleft()
+                    space.add(objs)
+
+                for i in range(len(space._remove_later)):
+                    objs = space._remove_later.popleft()
+                    space.remove(objs)
+
+                post_step = space._post_step_callbacks.copy()
+                for key in post_step:
+                    space._post_step_callbacks[key](self)
+                    del space._post_step_callbacks[key]
+            self.do_event.clear()
+            self.free_event.set()
 
 class Space(PickleMixin, object):
     """Spaces are the basic unit of simulation. You add rigid bodies, shapes
@@ -71,7 +95,7 @@ class Space(PickleMixin, object):
 
         self._handlers = {} # To prevent the gc to collect the callbacks.
 
-        self._post_step_callbacks = queue.Queue()
+        self._post_step_callbacks = {}
         self._removed_shapes = {}
 
         self._shapes = {}
@@ -80,9 +104,11 @@ class Space(PickleMixin, object):
         self._constraints = set()
         
         self._in_step = threading.Lock()
-        self._add_later = queue.Queue()
-        self._remove_later = queue.Queue()
+        self._add_later = collections.deque()
+        self._remove_later = collections.deque()
 
+        self.thread = AsyncHandler(self)
+        self.thread.start()
 
     def _get_self(self):
         return self
@@ -258,7 +284,7 @@ class Space(PickleMixin, object):
 
         free = self._in_step.acquire(False)
         if not free:
-            self._add_later.put(objs)
+            self._add_later.append(objs)
             return
 
         for o in objs:
@@ -290,7 +316,7 @@ class Space(PickleMixin, object):
         free = self._in_step.acquire(False)
 
         if not free:
-            self._remove_later.put(objs)
+            self._remove_later.append(objs)
             return
 
         for o in objs:
@@ -375,7 +401,7 @@ class Space(PickleMixin, object):
         """)
 
 
-    def step(self, dt):
+    def step(self, dt, blocking = True):
         """Update the space for the given time step. 
         
         Using a fixed time step is highly recommended. Doing so will increase 
@@ -404,21 +430,10 @@ class Space(PickleMixin, object):
             else:
                 cp.cpSpaceStep(self._space, dt)
             self._removed_shapes = {}
+            self.thread.do_event.set()
+        if blocking:
+            self.thread.free_event.wait()
 
-            while not self._add_later.empty():
-                objs = self._add_later.get()
-                self.add(objs)
-                self._add_later.task_done()
-
-            while not self._remove_later.empty():
-                objs = self._remove_later.get()
-                self.remove(objs)
-                self._remove_later.task_done()
-
-            while not self._post_step_callbacks.empty():
-                key = self._post_step_callbacks.get()
-                self._post_step_callbacks[key](self)
-                self._post_step_callbacks.task_done()
 
 
     def add_collision_handler(self, collision_type_a, collision_type_b):

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -289,6 +289,7 @@ class Space(PickleMixin, object):
         free = self._in_step.acquire(False)
 
         if not free:
+            self._remove_later.append(objs)
             return
 
         for o in objs:

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -4,7 +4,6 @@ import weakref
 import platform
 import copy
 import threading
-import collections
 
 from . import _chipmunk_cffi
 cp = _chipmunk_cffi.lib


### PR DESCRIPTION
In a multi-threaded environment, multiple shapes can end up with the same ID, tripping assertion errors.
This fixes that part. Didn't see a noticeable performance change, but mileage may vary.