### PR TITLE
Compile with only 64bit on latest MacOS, to avoid error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,11 @@ class build_chipmunk(build_ext, object):
 
             elif platform.system() == 'Darwin':
                 #No -O3 on OSX. There's a bug in the clang compiler when using O3.
-                compiler_preargs += ['-arch', 'i386', '-arch', 'x86_64']
+                mac_ver_float = float('.'.join(platform.mac_ver()[0].split('.')[:2]))
+                if mac_ver_float > 10.12:
+                    compiler_preargs += ['-arch', 'x86_64']
+                else:
+                    compiler_preargs += ['-arch', 'i386', '-arch', 'x86_64']
             
             elif platform.system() == 'Windows':
                 compiler_preargs += ['-shared']


### PR DESCRIPTION
Hi,

I'm not sure if this is the correct fix, but it gets around the i386 issue I was having installing pymunk:
https://github.com/viblo/pymunk/issues/143

i386 is deprecated on newer MacOS versions, so I guess more things will stop working with it.

We had to stop supporting i386 with pygame some time ago for various reasons, but I think the main thing was issues with binary wheels.