### PR TITLE
binary wheels for linux - "manylinux"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,18 @@ matrix:
   - os: osx
     osx_image: xcode9.1
     language: generic
-    env: 
+    env:
     - PYTHON="python3"
-    - TOXENV=py3 
+    - TOXENV=py3
     - PIP_INSTALL="pip install --user"
     - BUILD_CMD="python3 setup.py bdist_wheel"
   - os: osx
     osx_image: xcode9.1
     language: generic
-    env: 
+    env:
     - PYTHON=python2""
-    - TOXENV=py27 
-    - PIP_INSTALL="pip install --user" 
+    - TOXENV=py27
+    - PIP_INSTALL="pip install --user"
     - BUILD_CMD="python2 setup.py bdist_wheel"
   - os: linux
     env: TOXENV=py27
@@ -40,7 +40,7 @@ matrix:
   - os: linux
     env: TOXENV=py36
     python: 3.6
-# strange random hang error on pypy that is difficult to reproduce. 
+# strange random hang error on pypy that is difficult to reproduce.
 # Disable test for now.
 #  - os: linux
 #    env: TOXENV=pypy
@@ -50,6 +50,11 @@ matrix:
     python: pypy3
   - os: linux
     env: TOXENV=docs
+# create linux binary manylinux builds, see tools/manylinux-build
+  - sudo: required
+    services:
+      - docker
+    env: TOXENV=manylinux
   exclude:
   - env: TRAVIS_4681_WORKAROUND=1
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ matrix:
   - sudo: required
     services:
       - docker
-    env: TOXENV=manylinux
+    env:
+    - TOXENV=manylinux
+    - GITHUB_UPLOAD=yes
   exclude:
   - env: TRAVIS_4681_WORKAROUND=1
 before_install:

--- a/tools/manylinux-build/Makefile
+++ b/tools/manylinux-build/Makefile
@@ -1,0 +1,22 @@
+.PHONY: default
+default: all ;
+
+REPO_ROOT = $(abspath ../..)
+
+wheels-x64:
+	docker run --rm -v ${REPO_ROOT}:/io quay.io/pypa/manylinux1_x86_64 /io/tools/manylinux-build/build-wheels.sh
+
+wheels-x86:
+	docker run --rm -v ${REPO_ROOT}:/io quay.io/pypa/manylinux1_i686 /io/tools/manylinux-build/build-wheels.sh
+
+wheels: wheels-x64 wheels-x86
+
+pull-x64:
+	docker pull quay.io/pypa/manylinux1_x86_64
+
+pull-x86:
+	docker pull quay.io/pypa/manylinux1_i686
+
+pull: pull-x64 pull-x86
+
+all: pull wheels

--- a/tools/manylinux-build/README.rst
+++ b/tools/manylinux-build/README.rst
@@ -1,0 +1,152 @@
+Manylinux wheels
+================
+
+This is for building linux binary wheels. So "pip install pymunk" works on linux.
+
+tldr
+----
+
+cd tools/manylinux-build/
+make pull wheels
+
+# linux binary wheel files are in 'tools/manylinux-build/wheelhouse'
+
+Longer instructions
+-------------------
+
+The *manylinux1* tag (see `PEP 513 <https://www.python.org/dev/peps/pep-0513/>`__)
+refers to a specific set of core library minimum versions, which most recent
+desktop Linux distros have.
+To ensure that our libraries are ABI-compatible with these core libraries, we
+build on an old Linux distribution in a docker container.
+
+manylinux is an older linux with a fairly compatable ABI, so you can make linux binary
+wheels that run on many different linux distros.
+
+* https://github.com/pygame/pygame (README based on this one)
+* https://github.com/pypa/auditwheel
+* https://github.com/pypa/manylinux
+
+
+This is easiest on a Linux machine with the Docker daemon running. To get the
+prebuilt base images with pymunk dependencies::
+
+    make pull-x64    # 64 bit, or
+    make pull-x86    # 32 bit, or
+    make pull        # Both
+
+Then build the wheels::
+
+    make wheels-x64  # 64 bit, or
+    make wheels-x86  # 32 bit, or
+    make wheels      # both
+
+The wheels will be created in a directory called ``wheelhouse``.
+
+
+Virtual Machine
+---------------
+
+NOTE: you can run docker on Mac and Windows ok now, so a virtual machine may not be needed.
+
+
+Below are instructions on using a vagrant virtual machine, so we can build the wheels from
+mac, windows or linux boxes.
+
+
+These aren't meant to be copypasta'd in. Perhaps these can be worked into a script later::
+
+    # You should be in the base of the pymunk repo when you run all this.
+    $ pwd
+    /home/jblogs/pymunk
+
+    # Download many megabytes of ubuntu.
+    mkdir vagrant.xenial64
+    cd vagrant.xenial64
+    vagrant init ubuntu/xenial64
+
+    # edit your Vagrantfile to add /vagrant_pymunk synced folder.
+    # You pymunk folder is next to your vagrant
+    config.vm.synced_folder "../pymunk", "/vagrant_pymunk"
+
+    # now start vagrant.
+    vagrant up
+    vagrant ssh
+
+    # now we are on the vagrant ubuntu host
+    # We set up docker following these instructions for ubuntu-xenial
+    # https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce-1
+    sudo apt-get update
+    sudo apt-get remove docker docker-engine docker.io
+    sudo apt-get install apt-transport-https ca-certificates curl software-properties-common
+
+    # Now edit /etc/hosts so it has a first line with the hostname ubuntu-xenial in it.
+    # Otherwise docker does not start.
+    # 127.0.0.1 localhost ubuntu-xenial
+    # makes a /etc/hosts.bak in case something breaks.
+    sudo sed -i".bak" '/127.0.0.1 localhost/s/$/ ubuntu-xenial/' /etc/hosts
+
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+    sudo apt-get update
+
+    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+    sudo apt-get install docker-ce
+
+    # check that it runs.
+    sudo docker run hello-world
+
+
+    # We should have been in our python package clone root directory before we ran vagrant ssh
+    cd /vagrant_pymunk
+
+    # We need to be able to run docker as the ubuntu user.
+    sudo usermod -aG docker ubuntu
+    sudo usermod -aG docker $USER
+
+    # now log out of vagrant. Need to reload it because docker.
+    exit
+
+    vagrant reload
+    vagrant ssh
+
+    # now we can start docker. Should be started already.
+    sudo service docker start
+
+
+    cd /vagrant_pymunk/tools/manylinux-build
+
+    # To make the base docker images and push them to docker hub do these commands.
+    # Note, these have already been built, so only needed if rebuilding dependencies.
+    # https://hub.docker.com/u/pymunk/
+    #make base-images
+    #make push
+
+    # We use the prebuilt docker images, which should be quicker.
+    make wheels
+
+    # List the wheels we've built
+    ls -la wheelhouse
+
+    # Testing
+    export SDL_AUDIODRIVER=disk
+    export SDL_VIDEODRIVER=dummy
+
+    python3.5 -m venv anenv35
+    . ./anenv35/bin/activate
+    pip install wheelhouse/pymunk-*cp35-cp35m-manylinux1_x86_64.whl
+    # TODO: pymunk does not bundle tests.
+    # python -m pymunk.tests
+
+
+    # Now upload all the linux wheels to pypi.
+    # Make sure your PYPI vars are set. See .travis_osx_upload_whl.py
+    # Note you will need to increment the version in setup.py first.
+    cd ..
+    mkdir -p dist
+    rm -f dist/*.whl
+    cp tools/manylinux-build/wheelhouse/*.whl dist/
+
+    pip install twine
+    twine upload dist/*.whl

--- a/tools/manylinux-build/build-wheels.sh
+++ b/tools/manylinux-build/build-wheels.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e -x
+
+SUPPORTED_PYTHONS="cp27-cp27mu cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m"
+
+ls -la /io
+
+# Compile wheels
+for PYVER in $SUPPORTED_PYTHONS; do
+    rm -rf /io/Setup /io/build/
+    PYBIN="/opt/python/${PYVER}/bin"
+    ${PYBIN}/pip wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/pymunk*.whl; do
+    auditwheel repair $whl -w /io/tools/manylinux-build/wheelhouse/
+done
+
+# Dummy options for headless testing
+export SDL_AUDIODRIVER=disk
+export SDL_VIDEODRIVER=dummy
+
+# Install packages and test
+for PYVER in $SUPPORTED_PYTHONS; do
+    PYBIN="/opt/python/${PYVER}/bin"
+    ${PYBIN}/pip install cffi
+    ${PYBIN}/pip install pymunk --no-index -f /io/tools/manylinux-build/wheelhouse
+    # TODO: pymunk doesn't bundle tests in the package.
+    # (cd $HOME; ${PYBIN}/python -m pygame.tests --exclude opengl,music)
+done
+
+echo "Here are the binary wheels for linux:"
+ls /io/tools/manylinux-build/wheelhouse

--- a/tools/manylinux-build/build-wheels.sh
+++ b/tools/manylinux-build/build-wheels.sh
@@ -22,13 +22,14 @@ export SDL_AUDIODRIVER=disk
 export SDL_VIDEODRIVER=dummy
 
 # Install packages and test
-for PYVER in $SUPPORTED_PYTHONS; do
-    PYBIN="/opt/python/${PYVER}/bin"
-    ${PYBIN}/pip install cffi
-    ${PYBIN}/pip install pymunk --no-index -f /io/tools/manylinux-build/wheelhouse
-    # TODO: pymunk doesn't bundle tests in the package.
-    # (cd $HOME; ${PYBIN}/python -m pygame.tests --exclude opengl,music)
-done
+# for PYVER in $SUPPORTED_PYTHONS; do
+#     PYBIN="/opt/python/${PYVER}/bin"
+#     ${PYBIN}/pip install cffi
+#     ${PYBIN}/pip install pymunk --no-index -f /io/tools/manylinux-build/wheelhouse
+#     # TODO: pymunk doesn't bundle tests in the package.
+#     #       Maybe we can still test using the test folder?
+#     # (cd $HOME; ${PYBIN}/python -m pygame.tests --exclude opengl,music)
+# done
 
 echo "Here are the binary wheels for linux:"
 ls /io/tools/manylinux-build/wheelhouse

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,13 @@ envlist = py27,pypy,pypy3,py33,py34,py35,py36,docs
 
 [testenv]
 changedir = tests
-commands = 
+commands =
     python -c "import sys; print(sys.version); print(64*int(sys.maxsize > 2**32))"
     #python -c "import pymunk"
     python -m unittest discover -v
-    
-[testenv:py27]    
-commands = 
+
+[testenv:py27]
+commands =
     python -m doctests
 
 [testenv:docs]
@@ -22,3 +22,9 @@ basepython = python
 deps = sphinx
 changedir = docs
 commands = sphinx-build -W -E -b html ./src {envtmpdir}/html
+
+# create linux binary manylinux builds, see tools/manylinux-build
+[testenv:manylinux]
+basepython = python
+changedir = tools/manylinux-build
+commands = make pull wheels


### PR DESCRIPTION
Related to #146
This builds manylinux binary builds for linux. There's a README with full information.

Make the binary wheels like this using docker.
```bash
cd tools/manylinux-build/
make pull wheels
```
There are instructions in the included README for using a Ubuntu virtual machine "vagrant" (and virtualbox), if you don't have docker installed.

Travis CI is used to build them, but actually uploading them is done in https://github.com/viblo/pymunk/pull/149