### PR TITLE
The sudo tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
-python: 2.7
 git:
   depth: 3
-sudo: false
 env:
   global:
   - PYTHON="python"
@@ -58,7 +56,6 @@ matrix:
     python: 3.7
     dist: xenial
 # create linux binary manylinux builds, see tools/manylinux-build
-  - sudo: required
     services:
       - docker
     env:


### PR DESCRIPTION
__sudo: required__ no longer is...  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"