### PR TITLE
fix compile flags for 'aarch64' arm processors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,8 @@ class build_chipmunk(build_ext, object):
 
             else: # Linux, FreeBSD and others
                 compiler_preargs += ['-fPIC', '-O3']
-                if get_arch() == 64 and not platform.machine().startswith('arm'):
+                if get_arch() == 64 and not (platform.machine() == 'aarch64'
+                                             or platform.machine().startswith('arm')):
                     compiler_preargs += ['-m64']
                 elif get_arch() == 32 and not platform.machine().startswith('arm'):
                     compiler_preargs += ['-m32']


### PR DESCRIPTION
The new 64 bit arm architecture name is 'aarch64' and it can't handle the -m64 flag

raspberrypi4 and pinebookpro etc.

tested on odroid-n2