### PR TITLE
Updated logging usage

### DIFF
--- a/pymunk/body.py
+++ b/pymunk/body.py
@@ -32,6 +32,8 @@ _BodyType = int
 _PositionFunc = Callable[["Body", float], None]
 _VelocityFunc = Callable[["Body", Vec2d, float, float], None]
 
+_logger = logging.getLogger(__name__)
+
 
 class Body(PickleMixin, TypingAttrMixing, object):
     """A rigid body
@@ -198,7 +200,7 @@ class Body(PickleMixin, TypingAttrMixing, object):
         """
 
         def freebody(cp_body):  # type: ignore
-            logging.debug("bodyfree start %s", cp_body)
+            _logger.debug("bodyfree start %s", cp_body)
             cp_shapes = []
 
             @ffi.callback("cpBodyShapeIteratorFunc")
@@ -208,7 +210,7 @@ class Body(PickleMixin, TypingAttrMixing, object):
             lib.cpBodyEachShape(cp_body, cf1, ffi.NULL)
 
             for cp_shape in cp_shapes:
-                logging.debug("bodyfree remove shape %s %s", cp_body, cp_shape)
+                _logger.debug("bodyfree remove shape %s %s", cp_body, cp_shape)
                 cp_space = lib.cpShapeGetSpace(cp_shape)
                 if cp_space != ffi.NULL:
                     lib.cpSpaceRemoveShape(cp_space, cp_shape)
@@ -221,7 +223,7 @@ class Body(PickleMixin, TypingAttrMixing, object):
 
             lib.cpBodyEachConstraint(cp_body, cf2, ffi.NULL)
             for cp_constraint in cp_constraints:
-                logging.debug(
+                _logger.debug(
                     "bodyfree remove constraint %s %s", cp_body, cp_constraint
                 )
                 cp_space = lib.cpConstraintGetSpace(cp_constraint)
@@ -233,7 +235,7 @@ class Body(PickleMixin, TypingAttrMixing, object):
             if cp_space != ffi.NULL:
                 lib.cpSpaceRemoveBody(cp_space, cp_body)
 
-            logging.debug("bodyfree free %s", cp_body)
+            _logger.debug("bodyfree free %s", cp_body)
             lib.cpBodyFree(cp_body)
 
         if body_type == Body.DYNAMIC:

--- a/pymunk/constraints.py
+++ b/pymunk/constraints.py
@@ -81,6 +81,9 @@ from ._typing_attr import TypingAttrMixing
 from .vec2d import Vec2d
 
 
+_logger = logging.getLogger(__name__)
+
+
 class Constraint(PickleMixin, TypingAttrMixing, object):
     """Base class of all constraints.
 
@@ -111,7 +114,7 @@ class Constraint(PickleMixin, TypingAttrMixing, object):
             if cp_space != ffi.NULL:
                 lib.cpSpaceRemoveConstraint(cp_space, cp_constraint)
 
-            logging.debug("constraintfree %s", cp_constraint)
+            _logger.debug("constraintfree %s", cp_constraint)
             lib.cpConstraintFree(cp_constraint)
 
         self._constraint = ffi.gc(_constraint, constraintfree)

--- a/pymunk/shapes.py
+++ b/pymunk/shapes.py
@@ -19,6 +19,9 @@ from .transform import Transform
 from .vec2d import Vec2d
 
 
+_logger = logging.getLogger(__name__)
+
+
 class Shape(PickleMixin, TypingAttrMixing, object):
     """Base class for all the shapes.
 
@@ -58,12 +61,12 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         def shapefree(cp_shape):  # type: ignore
             cp_space = cp.cpShapeGetSpace(cp_shape)
             if cp_space != ffi.NULL:
-                logging.debug("shapefree remove from space %s %s", cp_space, cp_shape)
+                _logger.debug("shapefree remove from space %s %s", cp_space, cp_shape)
                 cp.cpSpaceRemoveShape(cp_space, cp_shape)
 
-            logging.debug("shapefree remove body %s", cp_shape)
+            _logger.debug("shapefree remove body %s", cp_shape)
             cp.cpShapeSetBody(cp_shape, ffi.NULL)
-            logging.debug("shapefree free %s", cp_shape)
+            _logger.debug("shapefree free %s", cp_shape)
             cp.cpShapeFree(cp_shape)
 
         self._shape = ffi.gc(_shape, shapefree)

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 _AddableObjects = Union[Body, Shape, Constraint]
 
+_logger = logging.getLogger(__name__)
+
 
 class Space(PickleMixin, object):
     """Spaces are the basic unit of simulation. You add rigid bodies, shapes
@@ -99,7 +101,7 @@ class Space(PickleMixin, object):
             freefunc = cp.cpSpaceFree
 
         def spacefree(cp_space):  # type: ignore
-            logging.debug("spacefree start %s", cp_space)
+            _logger.debug("spacefree start %s", cp_space)
             cp_shapes = []
 
             @ffi.callback("cpSpaceShapeIteratorFunc")
@@ -112,7 +114,7 @@ class Space(PickleMixin, object):
             # print("spacefree shapes", cp_space)
             cp.cpSpaceEachShape(cp_space, cf1, ffi.NULL)
             for cp_shape in cp_shapes:
-                logging.debug("spacefree remove shape %s %s", cp_space, cp_shape)
+                _logger.debug("spacefree remove shape %s %s", cp_space, cp_shape)
                 cp.cpSpaceRemoveShape(cp_space, cp_shape)
                 cp.cpShapeSetBody(cp_shape, ffi.NULL)
 
@@ -125,7 +127,7 @@ class Space(PickleMixin, object):
 
             cp.cpSpaceEachConstraint(cp_space, cf2, ffi.NULL)
             for cp_constraint in cp_constraints:
-                logging.debug(
+                _logger.debug(
                     "spacefree remove constraint %s %s", cp_space, cp_constraint
                 )
                 cp.cpSpaceRemoveConstraint(cp_space, cp_constraint)
@@ -139,10 +141,10 @@ class Space(PickleMixin, object):
 
             cp.cpSpaceEachBody(cp_space, cf3, ffi.NULL)
             for cp_body in cp_bodies:
-                logging.debug("spacefree remove body %s %s", cp_space, cp_body)
+                _logger.debug("spacefree remove body %s %s", cp_space, cp_body)
                 cp.cpSpaceRemoveBody(cp_space, cp_body)
 
-            logging.debug("spacefree free %s", cp_space)
+            _logger.debug("spacefree free %s", cp_space)
             freefunc(cp_space)
 
         self._space = ffi.gc(cp_space, spacefree)


### PR DESCRIPTION
Changed `logging.debug(...)` calls to `_logger = logging.getLogger(__name__)` and `_logger.debug(...)` so the logging output is easier to control. 

Reasoning: It's better approach and I don't want to see pymunk debug messages mixed with logs from my application during debugging.