### PR TITLE
Make most properties use conventional syntax to fix static typing

### DIFF
--- a/pymunk/arbiter.py
+++ b/pymunk/arbiter.py
@@ -38,11 +38,17 @@ class Arbiter(object):
         self._arbiter = _arbiter
         self._space = space
 
-    def _get_contact_point_set(self) -> ContactPointSet:
+    @property
+    def contact_point_set(self) -> ContactPointSet:
+        """Contact point sets make getting contact information from the 
+        Arbiter simpler.
+
+        Return `ContactPointSet`"""
         _set = lib.cpArbiterGetContactPointSet(self._arbiter)
         return ContactPointSet._from_cp(_set)
 
-    def _set_contact_point_set(self, point_set: ContactPointSet) -> None:
+    @contact_point_set.setter
+    def contact_point_set(self, point_set: ContactPointSet) -> None:
         # This has to be done by fetching a new Chipmunk point set, update it
         # according to whats passed in and the pass that back to chipmunk due
         # to the fact that ContactPointSet doesnt contain a reference to the
@@ -63,15 +69,6 @@ class Arbiter(object):
 
         lib.cpArbiterSetContactPointSet(self._arbiter, ffi.addressof(_set))
 
-    contact_point_set = property(
-        _get_contact_point_set,
-        _set_contact_point_set,
-        doc="""Contact point sets make getting contact information from the 
-        Arbiter simpler.
-        
-        Return `ContactPointSet`""",
-    )
-
     @property
     def shapes(self) -> Tuple["Shape", "Shape"]:
         """Get the shapes in the order that they were defined in the
@@ -87,46 +84,40 @@ class Arbiter(object):
         assert b is not None
         return a, b
 
-    def _get_restitution(self) -> float:
-        return lib.cpArbiterGetRestitution(self._arbiter)
-
-    def _set_restitution(self, restitution: float) -> None:
-        lib.cpArbiterSetRestitution(self._arbiter, restitution)
-
-    restitution = property(
-        _get_restitution,
-        _set_restitution,
-        doc="""The calculated restitution (elasticity) for this collision 
+    @property
+    def restitution(self) -> float:
+        """The calculated restitution (elasticity) for this collision 
         pair. 
-        
+
         Setting the value in a pre_solve() callback will override the value 
         calculated by the space. The default calculation multiplies the 
         elasticity of the two shapes together.
-        """,
-    )
+        """
+        return lib.cpArbiterGetRestitution(self._arbiter)
 
-    def _get_friction(self) -> float:
-        return lib.cpArbiterGetFriction(self._arbiter)
+    @restitution.setter
+    def restitution(self, restitution: float) -> None:
+        lib.cpArbiterSetRestitution(self._arbiter, restitution)
 
-    def _set_friction(self, friction: float) -> None:
-        lib.cpArbiterSetFriction(self._arbiter, friction)
+    @property
+    def friction(self) -> float:
+        """The calculated friction for this collision pair. 
 
-    friction = property(
-        _get_friction,
-        _set_friction,
-        doc="""The calculated friction for this collision pair. 
-        
         Setting the value in a pre_solve() callback will override the value 
         calculated by the space. The default calculation multiplies the 
         friction of the two shapes together.
-        """,
-    )
+        """
+        return lib.cpArbiterGetFriction(self._arbiter)
+
+    @friction.setter
+    def friction(self, friction: float) -> None:
+        lib.cpArbiterSetFriction(self._arbiter, friction)
 
     def _get_surface_velocity(self) -> Vec2d:
         v = lib.cpArbiterGetSurfaceVelocity(self._arbiter)
         return Vec2d(v.x, v.y)
 
-    def _set_surface_velocity(self, velocity: Vec2d) -> None:
+    def _set_surface_velocity(self, velocity: Tuple[float, float]) -> None:
         lib.cpArbiterSetSurfaceVelocity(self._arbiter, velocity)
 
     surface_velocity = property(

--- a/pymunk/collision_handler.py
+++ b/pymunk/collision_handler.py
@@ -72,7 +72,7 @@ class CollisionHandler(object):
         """
         return self._data
 
-    def _set_begin(self, func: Callable[[Arbiter, "Space", Any], bool]) -> None:
+    def _set_begin(self, func: _CollisionCallbackBool) -> None:
         self._begin = func
         self._handler.beginFunc = lib.ext_cpCollisionBeginFunc
 
@@ -98,7 +98,7 @@ class CollisionHandler(object):
         self._pre_solve = func
         self._handler.preSolveFunc = lib.ext_cpCollisionPreSolveFunc
 
-    def _get_pre_solve(self) -> Optional[Callable[[Arbiter, "Space", Any], bool]]:
+    def _get_pre_solve(self) -> Optional[_CollisionCallbackBool]:
         return self._pre_solve
 
     pre_solve = property(

--- a/pymunk/constraints.py
+++ b/pymunk/constraints.py
@@ -120,32 +120,22 @@ class Constraint(PickleMixin, TypingAttrMixing, object):
         self._data_handle = d  # to prevent gc to collect the handle
         lib.cpConstraintSetUserData(self._constraint, d)
 
-    def _get_max_force(self) -> float:
-        return lib.cpConstraintGetMaxForce(self._constraint)
-
-    def _set_max_force(self, f: float) -> None:
-        lib.cpConstraintSetMaxForce(self._constraint, f)
-
-    max_force = property(
-        _get_max_force,
-        _set_max_force,
-        doc="""The maximum force that the constraint can use to act on the two
+    @property
+    def max_force(self) -> float:
+        """The maximum force that the constraint can use to act on the two
         bodies.
 
         Defaults to infinity
-        """,
-    )
+        """
+        return lib.cpConstraintGetMaxForce(self._constraint)
 
-    def _get_error_bias(self) -> float:
-        return lib.cpConstraintGetErrorBias(self._constraint)
+    @max_force.setter
+    def max_force(self, f: float) -> None:
+        lib.cpConstraintSetMaxForce(self._constraint, f)
 
-    def _set_error_bias(self, error_bias: float) -> None:
-        lib.cpConstraintSetErrorBias(self._constraint, error_bias)
-
-    error_bias = property(
-        _get_error_bias,
-        _set_error_bias,
-        doc="""The percentage of joint error that remains unfixed after a
+    @property
+    def error_bias(self) -> float:
+        """The percentage of joint error that remains unfixed after a
         second.
 
         This works exactly the same as the collision bias property of a space,
@@ -154,42 +144,40 @@ class Constraint(PickleMixin, TypingAttrMixing, object):
 
         Defaults to pow(1.0 - 0.1, 60.0) meaning that it will correct 10% of
         the error every 1/60th of a second.
-        """,
-    )
+        """
+        return lib.cpConstraintGetErrorBias(self._constraint)
 
-    def _get_max_bias(self) -> float:
-        return lib.cpConstraintGetMaxBias(self._constraint)
+    @error_bias.setter
+    def error_bias(self, error_bias: float) -> None:
+        lib.cpConstraintSetErrorBias(self._constraint, error_bias)
 
-    def _set_max_bias(self, max_bias: float) -> None:
-        lib.cpConstraintSetMaxBias(self._constraint, max_bias)
-
-    max_bias = property(
-        _get_max_bias,
-        _set_max_bias,
-        doc="""The maximum speed at which the constraint can apply error
+    @property
+    def max_bias(self) -> float:
+        """The maximum speed at which the constraint can apply error
         correction.
 
         Defaults to infinity
-        """,
-    )
+        """
+        return lib.cpConstraintGetMaxBias(self._constraint)
 
-    def _get_collide_bodies(self) -> bool:
-        return lib.cpConstraintGetCollideBodies(self._constraint)
+    @max_bias.setter
+    def max_bias(self, max_bias: float) -> None:
+        lib.cpConstraintSetMaxBias(self._constraint, max_bias)
 
-    def _set_collide_bodies(self, collide_bodies: bool) -> None:
-        lib.cpConstraintSetCollideBodies(self._constraint, collide_bodies)
-
-    collide_bodies = property(
-        _get_collide_bodies,
-        _set_collide_bodies,
-        doc="""Constraints can be used for filtering collisions too.
+    @property
+    def collide_bodies(self) -> bool:
+        """Constraints can be used for filtering collisions too.
 
         When two bodies collide, Pymunk ignores the collisions if this property
         is set to False on any constraint that connects the two bodies.
         Defaults to True. This can be used to create a chain that self
         collides, but adjacent links in the chain do not collide.
-        """,
-    )
+        """
+        return lib.cpConstraintGetCollideBodies(self._constraint)
+
+    @collide_bodies.setter
+    def collide_bodies(self, collide_bodies: bool) -> None:
+        lib.cpConstraintSetCollideBodies(self._constraint, collide_bodies)
 
     @property
     def impulse(self) -> float:
@@ -358,13 +346,13 @@ class PinJoint(Constraint):
 
     anchor_b = property(_get_anchor_b, _set_anchor_b)
 
-    def _get_distance(self) -> float:
+    @property
+    def distance(self) -> float:
         return lib.cpPinJointGetDist(self._constraint)
 
-    def _set_distance(self, distance: float) -> None:
+    @distance.setter
+    def distance(self, distance: float) -> None:
         lib.cpPinJointSetDist(self._constraint, distance)
-
-    distance = property(_get_distance, _set_distance)
 
 
 class SlideJoint(Constraint):
@@ -421,21 +409,21 @@ class SlideJoint(Constraint):
 
     anchor_b = property(_get_anchor_b, _set_anchor_b)
 
-    def _get_min(self) -> float:
+    @property
+    def min(self) -> float:
         return lib.cpSlideJointGetMin(self._constraint)
 
-    def _set_min(self, min: float) -> None:
+    @min.setter
+    def min(self, min: float) -> None:
         lib.cpSlideJointSetMin(self._constraint, min)
 
-    min = property(_get_min, _set_min)
-
-    def _get_max(self) -> float:
+    @property
+    def max(self) -> float:
         return lib.cpSlideJointGetMax(self._constraint)
 
-    def _set_max(self, max: float) -> None:
+    @max.setter
+    def max(self, max: float) -> None:
         lib.cpSlideJointSetMax(self._constraint, max)
-
-    max = property(_get_max, _set_max)
 
 
 class PivotJoint(Constraint):
@@ -642,39 +630,32 @@ class DampedSpring(Constraint):
 
     anchor_b = property(_get_anchor_b, _set_anchor_b)
 
-    def _get_rest_length(self) -> float:
+    @property
+    def rest_length(self) -> float:
+        """The distance the spring wants to be."""
         return lib.cpDampedSpringGetRestLength(self._constraint)
 
-    def _set_rest_length(self, rest_length: float) -> None:
+    @rest_length.setter
+    def rest_length(self, rest_length: float) -> None:
         lib.cpDampedSpringSetRestLength(self._constraint, rest_length)
 
-    rest_length = property(
-        _get_rest_length,
-        _set_rest_length,
-        doc="""The distance the spring wants to be.""",
-    )
-
-    def _get_stiffness(self) -> float:
+    @property
+    def stiffness(self) -> float:
+        """The spring constant (Young's modulus)."""
         return lib.cpDampedSpringGetStiffness(self._constraint)
 
-    def _set_stiffness(self, stiffness: float) -> None:
+    @stiffness.setter
+    def stiffness(self, stiffness: float) -> None:
         lib.cpDampedSpringSetStiffness(self._constraint, stiffness)
 
-    stiffness = property(
-        _get_stiffness, _set_stiffness, doc="""The spring constant (Young's modulus)."""
-    )
-
-    def _get_damping(self) -> float:
+    @property
+    def damping(self) -> float:
+        """How soft to make the damping of the spring."""
         return lib.cpDampedSpringGetDamping(self._constraint)
 
-    def _set_damping(self, damping: float) -> None:
+    @damping.setter
+    def damping(self, damping: float) -> None:
         lib.cpDampedSpringSetDamping(self._constraint, damping)
-
-    damping = property(
-        _get_damping,
-        _set_damping,
-        doc="""How soft to make the damping of the spring.""",
-    )
 
     @staticmethod
     def spring_force(spring: "DampedSpring", dist: float) -> float:
@@ -737,39 +718,32 @@ class DampedRotarySpring(Constraint):
         )
         self._init(a, b, _constraint)
 
-    def _get_rest_angle(self) -> float:
+    @property
+    def rest_angle(self) -> float:
+        """The relative angle in radians that the bodies want to have"""
         return lib.cpDampedRotarySpringGetRestAngle(self._constraint)
 
-    def _set_rest_angle(self, rest_angle: float) -> None:
+    @rest_angle.setter
+    def rest_angle(self, rest_angle: float) -> None:
         lib.cpDampedRotarySpringSetRestAngle(self._constraint, rest_angle)
 
-    rest_angle = property(
-        _get_rest_angle,
-        _set_rest_angle,
-        doc="""The relative angle in radians that the bodies want to have""",
-    )
-
-    def _get_stiffness(self) -> float:
+    @property
+    def stiffness(self) -> float:
+        """The spring constant (Young's modulus)."""
         return lib.cpDampedRotarySpringGetStiffness(self._constraint)
 
-    def _set_stiffness(self, stiffness: float) -> None:
+    @stiffness.setter
+    def stiffness(self, stiffness: float) -> None:
         lib.cpDampedRotarySpringSetStiffness(self._constraint, stiffness)
 
-    stiffness = property(
-        _get_stiffness, _set_stiffness, doc="""The spring constant (Young's modulus)."""
-    )
-
-    def _get_damping(self) -> float:
+    @property
+    def damping(self) -> float:
+        """How soft to make the damping of the spring."""
         return lib.cpDampedRotarySpringGetDamping(self._constraint)
 
-    def _set_damping(self, damping: float) -> None:
+    @damping.setter
+    def damping(self, damping: float) -> None:
         lib.cpDampedRotarySpringSetDamping(self._constraint, damping)
-
-    damping = property(
-        _get_damping,
-        _set_damping,
-        doc="""How soft to make the damping of the spring.""",
-    )
 
     @staticmethod
     def spring_torque(spring: "DampedRotarySpring", relative_angle: float) -> float:
@@ -819,21 +793,21 @@ class RotaryLimitJoint(Constraint):
         _constraint = lib.cpRotaryLimitJointNew(a._body, b._body, min, max)
         self._init(a, b, _constraint)
 
-    def _get_min(self) -> float:
+    @property
+    def min(self) -> float:
         return lib.cpRotaryLimitJointGetMin(self._constraint)
 
-    def _set_min(self, min: float) -> None:
+    @min.setter
+    def min(self, min: float) -> None:
         lib.cpRotaryLimitJointSetMin(self._constraint, min)
 
-    min = property(_get_min, _set_min)
-
-    def _get_max(self) -> float:
+    @property
+    def max(self) -> float:
         return lib.cpRotaryLimitJointGetMax(self._constraint)
 
-    def _set_max(self, max: float) -> None:
+    @max.setter
+    def max(self, max: float) -> None:
         lib.cpRotaryLimitJointSetMax(self._constraint, max)
-
-    max = property(_get_max, _set_max)
 
 
 class RatchetJoint(Constraint):
@@ -850,29 +824,29 @@ class RatchetJoint(Constraint):
         _constraint = lib.cpRatchetJointNew(a._body, b._body, phase, ratchet)
         self._init(a, b, _constraint)
 
-    def _get_angle(self) -> float:
+    @property
+    def angle(self) -> float:
         return lib.cpRatchetJointGetAngle(self._constraint)
 
-    def _set_angle(self, angle: float) -> None:
+    @angle.setter
+    def angle(self, angle: float) -> None:
         lib.cpRatchetJointSetAngle(self._constraint, angle)
 
-    angle = property(_get_angle, _set_angle)
-
-    def _get_phase(self) -> float:
+    @property
+    def phase(self) -> float:
         return lib.cpRatchetJointGetPhase(self._constraint)
 
-    def _set_phase(self, phase: float) -> None:
+    @phase.setter
+    def phase(self, phase: float) -> None:
         lib.cpRatchetJointSetPhase(self._constraint, phase)
 
-    phase = property(_get_phase, _set_phase)
-
-    def _get_ratchet(self) -> float:
+    @property
+    def ratchet(self) -> float:
         return lib.cpRatchetJointGetRatchet(self._constraint)
 
-    def _set_ratchet(self, ratchet: float) -> None:
+    @ratchet.setter
+    def ratchet(self, ratchet: float) -> None:
         lib.cpRatchetJointSetRatchet(self._constraint, ratchet)
-
-    ratchet = property(_get_ratchet, _set_ratchet)
 
 
 class GearJoint(Constraint):
@@ -890,21 +864,21 @@ class GearJoint(Constraint):
         _constraint = lib.cpGearJointNew(a._body, b._body, phase, ratio)
         self._init(a, b, _constraint)
 
-    def _get_phase(self) -> float:
+    @property
+    def phase(self) -> float:
         return lib.cpGearJointGetPhase(self._constraint)
 
-    def _set_phase(self, phase: float) -> None:
+    @phase.setter
+    def phase(self, phase: float) -> None:
         lib.cpGearJointSetPhase(self._constraint, phase)
 
-    phase = property(_get_phase, _set_phase)
-
-    def _get_ratio(self) -> float:
+    @property
+    def ratio(self) -> float:
         return lib.cpGearJointGetRatio(self._constraint)
 
-    def _set_ratio(self, ratio: float) -> None:
+    @ratio.setter
+    def ratio(self, ratio: float) -> None:
         lib.cpGearJointSetRatio(self._constraint, ratio)
-
-    ratio = property(_get_ratio, _set_ratio)
 
 
 class SimpleMotor(Constraint):
@@ -922,12 +896,11 @@ class SimpleMotor(Constraint):
         _constraint = lib.cpSimpleMotorNew(a._body, b._body, rate)
         self._init(a, b, _constraint)
 
-    def _get_rate(self) -> float:
+    @property
+    def rate(self) -> float:
+        """The desired relative angular velocity"""
         return lib.cpSimpleMotorGetRate(self._constraint)
 
-    def _set_rate(self, rate: float) -> None:
+    @rate.setter
+    def rate(self, rate: float) -> None:
         lib.cpSimpleMotorSetRate(self._constraint, rate)
-
-    rate = property(
-        _get_rate, _set_rate, doc="""The desired relative angular velocity"""
-    )

--- a/pymunk/shapes.py
+++ b/pymunk/shapes.py
@@ -82,39 +82,33 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         cp.cpShapeSetUserData(self._shape, ffi.cast("cpDataPointer", Shape._id_counter))
         Shape._id_counter += 1
 
-    def _get_mass(self) -> float:
+    @property
+    def mass(self) -> float:
+        """The mass of this shape.
+
+        This is useful when you let Pymunk calculate the total mass and inertia
+        of a body from the shapes attached to it. (Instead of setting the body
+        mass and inertia directly)
+        """
         return cp.cpShapeGetMass(self._shape)
 
-    def _set_mass(self, mass: float) -> None:
+    @mass.setter
+    def mass(self, mass: float) -> None:
         cp.cpShapeSetMass(self._shape, mass)
 
-    mass = property(
-        _get_mass,
-        _set_mass,
-        doc="""The mass of this shape.
+    @property
+    def density(self) -> float:
+        """The density of this shape.
 
         This is useful when you let Pymunk calculate the total mass and inertia
         of a body from the shapes attached to it. (Instead of setting the body
         mass and inertia directly)
-        """,
-    )
-
-    def _get_density(self) -> float:
+        """
         return cp.cpShapeGetDensity(self._shape)
 
-    def _set_density(self, density: float) -> None:
+    @density.setter
+    def density(self, density: float) -> None:
         cp.cpShapeSetDensity(self._shape, density)
-
-    density = property(
-        _get_density,
-        _set_density,
-        doc="""The density of this shape.
-
-        This is useful when you let Pymunk calculate the total mass and inertia
-        of a body from the shapes attached to it. (Instead of setting the body
-        mass and inertia directly)
-        """,
-    )
 
     @property
     def moment(self) -> float:
@@ -132,79 +126,60 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         v = cp.cpShapeGetCenterOfGravity(self._shape)
         return Vec2d(v.x, v.y)
 
-    def _get_sensor(self) -> bool:
-        return bool(cp.cpShapeGetSensor(self._shape))
-
-    def _set_sensor(self, is_sensor: bool) -> None:
-        cp.cpShapeSetSensor(self._shape, is_sensor)
-
-    sensor = property(
-        _get_sensor,
-        _set_sensor,
-        doc="""A boolean value if this shape is a sensor or not.
+    @property
+    def sensor(self) -> bool:
+        """A boolean value if this shape is a sensor or not.
 
         Sensors only call collision callbacks, and never generate real
         collisions.
-        """,
-    )
+        """
+        return bool(cp.cpShapeGetSensor(self._shape))
 
-    def _get_collision_type(self) -> int:
-        return cp.cpShapeGetCollisionType(self._shape)
+    @sensor.setter
+    def sensor(self, is_sensor: bool) -> None:
+        cp.cpShapeSetSensor(self._shape, is_sensor)
 
-    def _set_collision_type(self, t: int) -> None:
-        cp.cpShapeSetCollisionType(self._shape, t)
-
-    collision_type = property(
-        _get_collision_type,
-        _set_collision_type,
-        doc="""User defined collision type for the shape.
+    @property
+    def collision_type(self) -> int:
+        """User defined collision type for the shape.
 
         See :py:meth:`Space.add_collision_handler` function for more
         information on when to use this property.
-        """,
-    )
+        """
+        return cp.cpShapeGetCollisionType(self._shape)
 
-    def _get_filter(self) -> ShapeFilter:
+    @collision_type.setter
+    def collision_type(self, t: int) -> None:
+        cp.cpShapeSetCollisionType(self._shape, t)
+
+    @property
+    def filter(self) -> ShapeFilter:
+        """Set the collision :py:class:`ShapeFilter` for this shape.
+        """
         f = cp.cpShapeGetFilter(self._shape)
         return ShapeFilter(f.group, f.categories, f.mask)
 
-    def _set_filter(self, f: ShapeFilter) -> None:
+    @filter.setter
+    def filter(self, f: ShapeFilter) -> None:
         cp.cpShapeSetFilter(self._shape, f)
 
-    filter = property(
-        _get_filter,
-        _set_filter,
-        doc="""Set the collision :py:class:`ShapeFilter` for this shape.
-        """,
-    )
-
-    def _get_elasticity(self) -> float:
-        return cp.cpShapeGetElasticity(self._shape)
-
-    def _set_elasticity(self, e: float) -> None:
-        cp.cpShapeSetElasticity(self._shape, e)
-
-    elasticity = property(
-        _get_elasticity,
-        _set_elasticity,
-        doc="""Elasticity of the shape.
+    @property
+    def elasticity(self) -> float:
+        """Elasticity of the shape.
 
         A value of 0.0 gives no bounce, while a value of 1.0 will give a
         'perfect' bounce. However due to inaccuracies in the simulation
         using 1.0 or greater is not recommended.
-        """,
-    )
+        """
+        return cp.cpShapeGetElasticity(self._shape)
 
-    def _get_friction(self) -> float:
-        return cp.cpShapeGetFriction(self._shape)
+    @elasticity.setter
+    def elasticity(self, e: float) -> None:
+        cp.cpShapeSetElasticity(self._shape, e)
 
-    def _set_friction(self, u: float) -> None:
-        cp.cpShapeSetFriction(self._shape, u)
-
-    friction = property(
-        _get_friction,
-        _set_friction,
-        doc="""Friction coefficient.
+    @property
+    def friction(self) -> float:
+        """Friction coefficient.
 
         Pymunk uses the Coulomb friction model, a value of 0.0 is
         frictionless.
@@ -234,14 +209,18 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         Teflon (PTFE)   Teflon  0.04
         Wood            Wood    0.4
         ==============  ======  ========
-        """,
-    )
+        """
+        return cp.cpShapeGetFriction(self._shape)
+
+    @friction.setter
+    def friction(self, u: float) -> None:
+        cp.cpShapeSetFriction(self._shape, u)
 
     def _get_surface_velocity(self) -> Vec2d:
         v = cp.cpShapeGetSurfaceVelocity(self._shape)
         return Vec2d(v.x, v.y)
 
-    def _set_surface_velocity(self, surface_v: Vec2d) -> None:
+    def _set_surface_velocity(self, surface_v: Tuple[float, float]) -> None:
         assert len(surface_v) == 2
         cp.cpShapeSetSurfaceVelocity(self._shape, surface_v)
 
@@ -256,10 +235,14 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         """,
     )
 
-    def _get_body(self) -> Optional["Body"]:
+    @property
+    def body(self) -> Optional["Body"]:
+        """The body this shape is attached to. Can be set to None to
+        indicate that this shape doesnt belong to a body."""
         return self._body
 
-    def _set_body(self, body: Optional["Body"]) -> None:
+    @body.setter
+    def body(self, body: Optional["Body"]) -> None:
         if self._body is not None:
             self._body._shapes.remove(self)
         body_body = ffi.NULL if body is None else body._body
@@ -267,13 +250,6 @@ class Shape(PickleMixin, TypingAttrMixing, object):
         if body is not None:
             body._shapes.add(self)
         self._body = body
-
-    body = property(
-        _get_body,
-        _set_body,
-        doc="""The body this shape is attached to. Can be set to None to
-        indicate that this shape doesnt belong to a body.""",
-    )
 
     def update(self, transform: Transform) -> BB:
         """Update, cache and return the bounding box of a shape with an
@@ -492,17 +468,17 @@ class Segment(Shape):
         _shape = cp.cpSegmentShapeNew(body_body, a, b, radius)
         self._init(body, _shape)
 
-    def _get_a(self) -> Vec2d:
+    @property
+    def a(self) -> Vec2d:
+        """The first of the two endpoints for this segment"""
         v = cp.cpSegmentShapeGetA(self._shape)
         return Vec2d(v.x, v.y)
 
-    a = property(_get_a, doc="""The first of the two endpoints for this segment""")
-
-    def _get_b(self) -> Vec2d:
+    @property
+    def b(self) -> Vec2d:
+        """The second of the two endpoints for this segment"""
         v = cp.cpSegmentShapeGetB(self._shape)
         return Vec2d(v.x, v.y)
-
-    b = property(_get_b, doc="""The second of the two endpoints for this segment""")
 
     def unsafe_set_endpoints(
         self, a: Tuple[float, float], b: Tuple[float, float]

--- a/pymunk/space.py
+++ b/pymunk/space.py
@@ -187,16 +187,9 @@ class Space(PickleMixin, object):
             # assert self._static_body is not None
         return self._static_body
 
-    def _set_iterations(self, value: int) -> None:
-        cp.cpSpaceSetIterations(self._space, value)
-
-    def _get_iterations(self) -> int:
-        return cp.cpSpaceGetIterations(self._space)
-
-    iterations = property(
-        _get_iterations,
-        _set_iterations,
-        doc="""Iterations allow you to control the accuracy of the solver.
+    @property
+    def iterations(self) -> int:
+        """Iterations allow you to control the accuracy of the solver.
 
         Defaults to 10.
 
@@ -212,8 +205,12 @@ class Space(PickleMixin, object):
         the number of iterations lets you balance between CPU usage and the
         accuracy of the physics. Pymunk's default of 10 iterations is
         sufficient for most simple games.
-        """,
-    )
+        """
+        return cp.cpSpaceGetIterations(self._space)
+
+    @iterations.setter
+    def iterations(self, value: int) -> None:
+        cp.cpSpaceSetIterations(self._space, value)
 
     def _set_gravity(self, gravity_vector: Tuple[float, float]) -> None:
         assert len(gravity_vector) == 2
@@ -234,81 +231,62 @@ class Space(PickleMixin, object):
         """,
     )
 
-    def _set_damping(self, damping: float) -> None:
-        cp.cpSpaceSetDamping(self._space, damping)
-
-    def _get_damping(self) -> float:
-        return cp.cpSpaceGetDamping(self._space)
-
-    damping = property(
-        _get_damping,
-        _set_damping,
-        doc="""Amount of simple damping to apply to the space.
+    @property
+    def damping(self) -> float:
+        """Amount of simple damping to apply to the space.
 
         A value of 0.9 means that each body will lose 10% of its velocity per
         second. Defaults to 1. Like gravity, it can be overridden on a per
         body basis.
-        """,
-    )
+        """
+        return cp.cpSpaceGetDamping(self._space)
 
-    def _set_idle_speed_threshold(self, idle_speed_threshold: float) -> None:
-        cp.cpSpaceSetIdleSpeedThreshold(self._space, idle_speed_threshold)
+    @damping.setter
+    def damping(self, damping: float) -> None:
+        cp.cpSpaceSetDamping(self._space, damping)
 
-    def _get_idle_speed_threshold(self) -> float:
-        return cp.cpSpaceGetIdleSpeedThreshold(self._space)
-
-    idle_speed_threshold = property(
-        _get_idle_speed_threshold,
-        _set_idle_speed_threshold,
-        doc="""Speed threshold for a body to be considered idle.
+    @property
+    def idle_speed_threshold(self) -> float:
+        """Speed threshold for a body to be considered idle.
 
         The default value of 0 means the space estimates a good threshold
         based on gravity.
-        """,
-    )
+        """
+        return cp.cpSpaceGetIdleSpeedThreshold(self._space)
 
-    def _set_sleep_time_threshold(self, sleep_time_threshold: float) -> None:
-        cp.cpSpaceSetSleepTimeThreshold(self._space, sleep_time_threshold)
+    @idle_speed_threshold.setter
+    def idle_speed_threshold(self, idle_speed_threshold: float) -> None:
+        cp.cpSpaceSetIdleSpeedThreshold(self._space, idle_speed_threshold)
 
-    def _get_sleep_time_threshold(self) -> float:
-        return cp.cpSpaceGetSleepTimeThreshold(self._space)
-
-    sleep_time_threshold = property(
-        _get_sleep_time_threshold,
-        _set_sleep_time_threshold,
-        doc="""Time a group of bodies must remain idle in order to fall
+    @property
+    def sleep_time_threshold(self) -> float:
+        """Time a group of bodies must remain idle in order to fall
         asleep.
 
         The default value of `inf` disables the sleeping algorithm.
-        """,
-    )
+        """
+        return cp.cpSpaceGetSleepTimeThreshold(self._space)
 
-    def _set_collision_slop(self, collision_slop: float) -> None:
-        cp.cpSpaceSetCollisionSlop(self._space, collision_slop)
+    @sleep_time_threshold.setter
+    def sleep_time_threshold(self, sleep_time_threshold: float) -> None:
+        cp.cpSpaceSetSleepTimeThreshold(self._space, sleep_time_threshold)
 
-    def _get_collision_slop(self) -> float:
-        return cp.cpSpaceGetCollisionSlop(self._space)
-
-    collision_slop = property(
-        _get_collision_slop,
-        _set_collision_slop,
-        doc="""Amount of overlap between shapes that is allowed.
+    @property
+    def collision_slop(self) -> float:
+        """Amount of overlap between shapes that is allowed.
 
         To improve stability, set this as high as you can without noticeable
         overlapping. It defaults to 0.1.
-        """,
-    )
+        """
+        return cp.cpSpaceGetCollisionSlop(self._space)
 
-    def _set_collision_bias(self, collision_bias: float) -> None:
-        cp.cpSpaceSetCollisionBias(self._space, collision_bias)
+    @collision_slop.setter
+    def collision_slop(self, collision_slop: float) -> None:
+        cp.cpSpaceSetCollisionSlop(self._space, collision_slop)
 
-    def _get_collision_bias(self) -> float:
-        return cp.cpSpaceGetCollisionBias(self._space)
-
-    collision_bias = property(
-        _get_collision_bias,
-        _set_collision_bias,
-        doc="""Determines how fast overlapping shapes are pushed apart.
+    @property
+    def collision_bias(self) -> float:
+        """Determines how fast overlapping shapes are pushed apart.
 
         Pymunk allows fast moving objects to overlap, then fixes the overlap
         over time. Overlapping objects are unavoidable even if swept
@@ -322,19 +300,16 @@ class Space(PickleMixin, object):
 
         ..Note::
             Very very few games will need to change this value.
-        """,
-    )
+        """
+        return cp.cpSpaceGetCollisionBias(self._space)
 
-    def _set_collision_persistence(self, collision_persistence: float) -> None:
-        cp.cpSpaceSetCollisionPersistence(self._space, collision_persistence)
+    @collision_bias.setter
+    def collision_bias(self, collision_bias: float) -> None:
+        cp.cpSpaceSetCollisionBias(self._space, collision_bias)
 
-    def _get_collision_persistence(self) -> float:
-        return cp.cpSpaceGetCollisionPersistence(self._space)
-
-    collision_persistence = property(
-        _get_collision_persistence,
-        _set_collision_persistence,
-        doc="""The number of frames the space keeps collision solutions
+    @property
+    def collision_persistence(self) -> float:
+        """The number of frames the space keeps collision solutions
         around for.
 
         Helps prevent jittering contacts from getting worse. This defaults
@@ -342,19 +317,20 @@ class Space(PickleMixin, object):
 
         ..Note::
             Very very few games will need to change this value.
-        """,
-    )
+        """
+        return cp.cpSpaceGetCollisionPersistence(self._space)
 
-    def _get_current_time_step(self) -> float:
-        return cp.cpSpaceGetCurrentTimeStep(self._space)
+    @collision_persistence.setter
+    def collision_persistence(self, collision_persistence: float) -> None:
+        cp.cpSpaceSetCollisionPersistence(self._space, collision_persistence)
 
-    current_time_step = property(
-        _get_current_time_step,
-        doc="""Retrieves the current (if you are in a callback from
+    @property
+    def current_time_step(self) -> float:
+        """Retrieves the current (if you are in a callback from
         Space.step()) or most recent (outside of a Space.step() call)
         timestep.
-        """,
-    )
+        """
+        return cp.cpSpaceGetCurrentTimeStep(self._space)
 
     def add(self, *objs: _AddableObjects) -> None:
         """Add one or many shapes, bodies or constraints (joints) to the space

--- a/pymunk/space_debug_draw_options.py
+++ b/pymunk/space_debug_draw_options.py
@@ -98,16 +98,9 @@ class SpaceDebugDrawOptions(object):
             | SpaceDebugDrawOptions.DRAW_COLLISION_POINTS
         )
 
-    def _get_shape_outline_color(self) -> SpaceDebugColor:
-        return self._c(self._options.shapeOutlineColor)
-
-    def _set_shape_outline_color(self, c: SpaceDebugColor) -> None:
-        self._options.shapeOutlineColor = c
-
-    shape_outline_color = property(
-        _get_shape_outline_color,
-        _set_shape_outline_color,
-        doc="""The outline color of shapes.
+    @property
+    def shape_outline_color(self) -> SpaceDebugColor:
+        """The outline color of shapes.
         
         Should be a tuple of 4 ints between 0 and 255 (r,g,b,a).
 
@@ -124,22 +117,19 @@ class SpaceDebugDrawOptions(object):
         >>> s.debug_draw(options)
         draw_circle (Vec2d(0.0, 0.0), 0.0, 10.0, SpaceDebugColor(r=10.0, g=20.0, b=30.0, a=40.0), SpaceDebugColor(r=149.0, g=165.0, b=166.0, a=255.0))
 
-        """,
-    )
+        """
+        return self._c(self._options.shapeOutlineColor)
 
-    def _get_constraint_color(self) -> SpaceDebugColor:
-        return self._c(self._options.constraintColor)
+    @shape_outline_color.setter
+    def shape_outline_color(self, c: SpaceDebugColor) -> None:
+        self._options.shapeOutlineColor = c
 
-    def _set_constraint_color(self, c: SpaceDebugColor) -> None:
-        self._options.constraintColor = c
-
-    constraint_color = property(
-        _get_constraint_color,
-        _set_constraint_color,
-        doc="""The color of constraints.
+    @property
+    def constraint_color(self) -> SpaceDebugColor:
+        """The color of constraints.
 
         Should be a tuple of 4 ints between 0 and 255 (r,g,b,a).
-        
+
         Example:
 
         >>> import pymunk
@@ -156,19 +146,16 @@ class SpaceDebugDrawOptions(object):
         draw_dot (5.0, Vec2d(0.0, 0.0), SpaceDebugColor(r=10.0, g=20.0, b=30.0, a=40.0))
         draw_dot (5.0, Vec2d(0.0, 0.0), SpaceDebugColor(r=10.0, g=20.0, b=30.0, a=40.0))
 
-        """,
-    )
+        """
+        return self._c(self._options.constraintColor)
 
-    def _get_collision_point_color(self) -> SpaceDebugColor:
-        return self._c(self._options.collisionPointColor)
+    @constraint_color.setter
+    def constraint_color(self, c: SpaceDebugColor) -> None:
+        self._options.constraintColor = c
 
-    def _set_collision_point_color(self, c: SpaceDebugColor) -> None:
-        self._options.collisionPointColor = c
-
-    collision_point_color = property(
-        _get_collision_point_color,
-        _set_collision_point_color,
-        doc="""The color of collisions.
+    @property
+    def collision_point_color(self) -> SpaceDebugColor:
+        """The color of collisions.
 
         Should be a tuple of 4 ints between 0 and 255 (r,g,b,a).
         
@@ -191,8 +178,12 @@ class SpaceDebugDrawOptions(object):
         draw_circle (Vec2d(0.0, 0.0), 0.0, 10.0, SpaceDebugColor(r=44.0, g=62.0, b=80.0, a=255.0), SpaceDebugColor(r=52.0, g=152.0, b=219.0, a=255.0))
         draw_circle (Vec2d(0.0, 0.0), 0.0, 10.0, SpaceDebugColor(r=44.0, g=62.0, b=80.0, a=255.0), SpaceDebugColor(r=149.0, g=165.0, b=166.0, a=255.0))
         draw_segment (Vec2d(8.0, 0.0), Vec2d(-8.0, 0.0), SpaceDebugColor(r=10.0, g=20.0, b=30.0, a=40.0))
-        """,
-    )
+        """
+        return self._c(self._options.collisionPointColor)
+
+    @collision_point_color.setter
+    def collision_point_color(self, c: SpaceDebugColor) -> None:
+        self._options.collisionPointColor = c
 
     def __enter__(self) -> None:
         pass
@@ -208,16 +199,9 @@ class SpaceDebugDrawOptions(object):
     def _c(self, color: ffi.CData) -> SpaceDebugColor:
         return SpaceDebugColor(color.r, color.g, color.b, color.a)
 
-    def _get_flags(self) -> _DrawFlags:
-        return self._options.flags
-
-    def _set_flags(self, f: _DrawFlags) -> None:
-        self._options.flags = f
-
-    flags = property(
-        _get_flags,
-        _set_flags,
-        doc="""Bit flags which of shapes, joints and collisions should be drawn.
+    @property
+    def flags(self) -> _DrawFlags:
+        """Bit flags which of shapes, joints and collisions should be drawn.
 
         By default all 3 flags are set, meaning shapes, joints and collisions 
         will be drawn.
@@ -235,7 +219,7 @@ class SpaceDebugDrawOptions(object):
         >>> s.add(pymunk.Circle(s.static_body, 3))
         >>> s.step(0.01)
         >>> options = pymunk.SpaceDebugDrawOptions() 
-        
+
         >>> # Only draw the shapes, nothing else:
         >>> options.flags = pymunk.SpaceDebugDrawOptions.DRAW_SHAPES
         >>> s.debug_draw(options) 
@@ -249,21 +233,17 @@ class SpaceDebugDrawOptions(object):
         draw_circle (Vec2d(0.0, 0.0), 0.0, 10.0, SpaceDebugColor(r=44.0, g=62.0, b=80.0, a=255.0), SpaceDebugColor(r=52.0, g=152.0, b=219.0, a=255.0))
         draw_circle (Vec2d(0.0, 0.0), 0.0, 3.0, SpaceDebugColor(r=44.0, g=62.0, b=80.0, a=255.0), SpaceDebugColor(r=149.0, g=165.0, b=166.0, a=255.0))
         draw_segment (Vec2d(1.0, 0.0), Vec2d(-8.0, 0.0), SpaceDebugColor(r=231.0, g=76.0, b=60.0, a=255.0))
-        
-        """,
-    )
 
-    def _get_transform(self) -> Transform:
-        t = self._options.transform
-        return Transform(t.a, t.b, t.c, t.d, t.tx, t.ty)
+        """
+        return self._options.flags
 
-    def _set_transform(self, t: Transform) -> None:
-        self._options.transform = t
+    @flags.setter
+    def flags(self, f: _DrawFlags) -> None:
+        self._options.flags = f
 
-    transform = property(
-        _get_transform,
-        _set_transform,
-        doc="""The transform is applied before drawing, e.g for scaling or 
+    @property
+    def transform(self) -> Transform:
+        """The transform is applied before drawing, e.g for scaling or 
         translation.
 
         Example: 
@@ -281,13 +261,18 @@ class SpaceDebugDrawOptions(object):
         >>> options.transform = pymunk.Transform.translation(2,3)
         >>> s.debug_draw(options)
         draw_circle (Vec2d(2.0, 3.0), 0.0, 10.0, SpaceDebugColor(r=44.0, g=62.0, b=80.0, a=255.0), SpaceDebugColor(r=149.0, g=165.0, b=166.0, a=255.0))
-        
+
         .. Note::
             Not all tranformations are supported by the debug drawing logic. 
             Uniform scaling and translation are supported, but not rotation,
             linear stretching or shearing. 
-        """,
-    )
+        """
+        t = self._options.transform
+        return Transform(t.a, t.b, t.c, t.d, t.tx, t.ty)
+
+    @transform.setter
+    def transform(self, t: Transform) -> None:
+        self._options.transform = t
 
     def draw_circle(
         self,


### PR DESCRIPTION
Fixes #272

Turn most properties that use functional syntax (`x = property(_get, _set, doc="")`) into normal properties using the decorator syntax.
Additionally, a few minor type annotation fixes on some properties.