### PR TITLE
doc: fix reference to non-existing method

### DIFF
--- a/pymunk/shapes.py
+++ b/pymunk/shapes.py
@@ -135,7 +135,7 @@ class Shape(PickleMixin, TypingAttrMixing, object):
 
         Defaults to 0.
 
-        See the :py:meth:`Space.add_collision_handler` function for more
+        See the :py:meth:`Space.on_collision` function for more
         information on when to use this property.
         """
         return cp.cpShapeGetCollisionType(self._shape)


### PR DESCRIPTION
It's confusing that up-to-date documentation (https://www.pymunk.org/en/latest/pymunk.html#pymunk.Poly.collision_type) references add_collision_handler, which seems to be removed (also this isn't found in changelogs! Maybe happened in 7.0.0?)

`on_collision` seems to document collision_types, so reference that instead.
